### PR TITLE
Ignore blank audio and do not process further

### DIFF
--- a/whisper_server.py
+++ b/whisper_server.py
@@ -362,7 +362,11 @@ class WhisperServer:
                 )
             )
             raw_text = result["text"]
-            logging.info(f"Raw transcription result: {raw_text}")
+            logging.info(f"Raw transcription result: '{raw_text}'")
+
+            # Ignore blank audio as nothing has been recorded
+            if raw_text.strip() == "[BLANK_AUDIO]" or raw_text.strip() == "":
+                return
 
             # Step 1: general cleanup
             cleaned_text = custom_cleanup_text(raw_text, self.word_mappings)


### PR DESCRIPTION
Whisper will output the raw transcription as an empty string or `[BLANK_AUDIO]` if nothing was recorded. If this is the case then do not perform any further processing.