### PR TITLE
Changed the trigger words for sending text to the DCS kneeboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This script preserves BojoteX original vision for the code and copies the comman
 The original repo can be found here: [https://github.com/BojoteX/KneeboardWhisper](https://github.com/BojoteX/KneeboardWhisper?tab=readme-ov-file#troubleshooting)
 
 Do the following to enable DCS Kneeboard to transcribe what you say:
-Once completed, you must say "Copy" followed by what you would like to transcribe to kneeboard/clipboard
+Once completed, you must say "Copy to DCS" followed by what you would like to transcribe to kneeboard/clipboard
 
 ![assignments](https://github.com/user-attachments/assets/6528e6a7-4114-4fdb-a1bc-1ed68bd6a1f8)
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ This script preserves BojoteX original vision for the code and copies the comman
 The original repo can be found here: [https://github.com/BojoteX/KneeboardWhisper](https://github.com/BojoteX/KneeboardWhisper?tab=readme-ov-file#troubleshooting)
 
 Do the following to enable DCS Kneeboard to transcribe what you say:
-Once completed, you must say "Copy to DCS" followed by what you would like to transcribe to kneeboard/clipboard
+Once completed, you must say "Note" followed by what you would like to transcribe to kneeboard/clipboard
 
 ![assignments](https://github.com/user-attachments/assets/6528e6a7-4114-4fdb-a1bc-1ed68bd6a1f8)
 

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -427,12 +427,12 @@ class WhisperServer:
 
     def send_to_voiceattack(self, text):
         """
-        If text contains the trigger phrase "copy", then:
+        If text contains the trigger phrase "copy to dcs", then:
           1) Remove that phrase from text
           2) Send ONLY to the kneeboard (not to VoiceAttack)
         Otherwise, send the text to VoiceAttack as usual
         """
-        trigger_phrase = "copy"
+        trigger_phrase = "copy to dcs"
 
         # Check for trigger phrase in a case-insensitive manner
         if trigger_phrase in text.lower():
@@ -442,12 +442,12 @@ class WhisperServer:
 
             # Copy the resulting text to the clipboard
             pyperclip.copy(text_for_kneeboard)
-            logging.info("Text copied to clipboard for kneeboard.")
+            logging.info("Text copied to clipboard for DCS kneeboard.")
 
             # Simulate kneeboard hotkeys
             try:
                 keyboard.press_and_release('ctrl+alt+p')
-                logging.info("DCS Kneeboard Populated")
+                logging.info("DCS kneeboard populated")
             except Exception as e:
                 logging.error(f"Failed to simulate keyboard shortcut: {e}")
 

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -427,18 +427,17 @@ class WhisperServer:
 
     def send_to_voiceattack(self, text):
         """
-        If text contains the trigger phrase "copy to dcs", then:
+        If text starts with the trigger phrase "note ", then:
           1) Remove that phrase from text
           2) Send ONLY to the kneeboard (not to VoiceAttack)
         Otherwise, send the text to VoiceAttack as usual
         """
-        trigger_phrase = "copy to dcs"
+        trigger_phrase = "note "
 
         # Check for trigger phrase in a case-insensitive manner
-        if trigger_phrase in text.lower():
+        if text.lower().startswith(trigger_phrase):
             # Strip out the phrase so it doesn't go anywhere else
-            pattern = re.compile(re.escape(trigger_phrase), re.IGNORECASE)
-            text_for_kneeboard = pattern.sub("", text).strip()
+            text_for_kneeboard = text[5:].strip()
 
             # Copy the resulting text to the clipboard
             pyperclip.copy(text_for_kneeboard)


### PR DESCRIPTION
The trigger word was previously "Copy". This meant that VoiceAttack was skipped for any sentence containing that word. This breaks integration with VAICOM and other usages of that word. It was also looking anyway in the sentence for this. This is now "Note" and the sentence must start with it, it is stripped from the final message sent to DCS and not sent to VoiceAttack.