### PR TITLE
Display a UI window and output logging to it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ soundfile
 text2digits
 pystray
 pillow
+pid
 --extra-index-url https://download.pytorch.org/whl/cu118
 torch

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -478,7 +478,7 @@ class WhisperAttack:
         start_logging()
         self.root = root
         self.root.title("WhisperAttack")
-        text_area = scrolledtext.ScrolledText(root, wrap=tk.WORD, width=100, height=50)
+        text_area = scrolledtext.ScrolledText(root, wrap=tk.WORD, width=100, height=50, state="disabled")
         self.writer = WhisperAttackWriter(text_area)
         threading.Thread(daemon=True, target=lambda: icon.run(setup=self.startup)).start()
 
@@ -487,7 +487,7 @@ class WhisperAttack:
         server = WhisperServer(self.writer)
         server.run_server()
 
-TAG_BLACK= 'black'
+TAG_BLACK = 'black'
 TAG_BLUE = 'blue'
 TAG_GREEN = 'green'
 TAG_GREY = 'grey'
@@ -504,8 +504,11 @@ class WhisperAttackWriter:
         self.text_area.tag_configure(TAG_RED, foreground=TAG_RED)
         
     def write(self, text, tag):
+        self.text_area.config(state="normal")
         self.text_area.insert(tk.END, text + "\n", tag)
         self.text_area.see(tk.END)
+        self.text_area.config(state="disabled")
+
 
 def shut_down(icon):
     logging.info("Shutting down server...")

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -161,7 +161,7 @@ def custom_cleanup_text(text, word_mappings):
     text = t2d.convert(text)
     text = re.sub(r"(?<=\d)-(?=\d)", " ", text)
     text = re.sub(r'\b0\d+\b', lambda x: ' '.join(x.group()), text)
-    text = re.sub(r"([^\w\s.])([\s-])", " ", text)
+    text = re.sub(r"([^\w\s])*(?:[^\w\-\w])", " ", text)
     text = re.sub(r"\s+", " ", text).strip()
     return text
 

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -360,7 +360,7 @@ class WhisperServer:
                 raw_text += f"{segment.text}"
 
             logging.info(f"Raw transcription result: '{raw_text}'")
-            self.writer.write(f"Raw transcription result: '{raw_text}'", TAG_BLUE)
+            self.writer.write(f"Raw transcribed text: '{raw_text}'", TAG_BLUE)
 
             # Ignore blank audio as nothing has been recorded
             if raw_text.strip() == "[BLANK_AUDIO]" or raw_text.strip() == "":
@@ -408,6 +408,7 @@ class WhisperServer:
             # Simulate kneeboard hotkeys
             try:
                 keyboard.press_and_release('ctrl+alt+p')
+                self.writer.write(f"Sent text to DCS kneeboard: {text}", TAG_GREEN)
                 logging.info("DCS kneeboard populated")
             except Exception as e:
                 logging.error(f"Failed to simulate keyboard shortcut: {e}")
@@ -423,8 +424,8 @@ class WhisperServer:
 
         try:
             logging.info(f"Sending recognized text to VoiceAttack: {text}")
-            self.writer.write(f"Sending recognized text to VoiceAttack: {text}", TAG_GREEN)
             subprocess.call([self.voiceattack, '-command', text])
+            self.writer.write(f"Sent text to VoiceAttack: {text}", TAG_GREEN)
         except Exception as e:
             logging.error(f"Error calling VoiceAttack: {e}")
             self.writer.write(f"Error calling VoiceAttack: {e}", TAG_RED)

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -240,7 +240,7 @@ class WhisperServer:
                 self.writer.write(f"Failed to load word mappings from {WORD_MAPPINGS_TEXT_FILE}: {e}", TAG_RED)
         else:
             logging.warning(f"{WORD_MAPPINGS_TEXT_FILE} not found; no custom word mappings loaded.")
-            self.writer.write(f"{WORD_MAPPINGS_TEXT_FILE} not found; no custom word mappings loaded.", TAG_RED)
+            self.writer.write(f"{WORD_MAPPINGS_TEXT_FILE} not found; no custom word mappings loaded.", TAG_ORANGE)
 
         if os.path.isfile(FUZZY_WORDS_TEXT_FILE):
             try:
@@ -255,7 +255,7 @@ class WhisperServer:
                 self.writer.write(f"Failed to load fuzzy words from {FUZZY_WORDS_TEXT_FILE}: {e}", TAG_RED)
         else:
             logging.warning(f"{FUZZY_WORDS_TEXT_FILE} not found; fuzzy matching list is empty.")
-            self.writer.write(f"{FUZZY_WORDS_TEXT_FILE} not found; fuzzy matching list is empty.", TAG_RED)
+            self.writer.write(f"{FUZZY_WORDS_TEXT_FILE} not found; fuzzy matching list is empty.", TAG_ORANGE)
 
     ###############################################################################
     # WHISPER LOADING
@@ -282,6 +282,7 @@ class WhisperServer:
     def start_recording(self):
         if self.recording:
             logging.info("Already recording—ignoring start command.")
+            self.writer.write("Already recording—ignoring start command", TAG_ORANGE)
             return
         logging.info("Starting recording...")
         self.writer.write("Starting recording...", TAG_GREY)
@@ -308,6 +309,7 @@ class WhisperServer:
     def stop_and_transcribe(self):
         if not self.recording:
             logging.warning("Not currently recording—ignoring stop command.")
+            self.writer.write("Not currently recording—ignoring stop command", TAG_ORANGE)
             return
         logging.info("Stopping recording...")
         self.writer.write("Stopped recording", TAG_GREY)
@@ -443,7 +445,7 @@ class WhisperServer:
             shut_down(icon)
         else:
             logging.warning(f"Unknown command: {cmd}")
-            self.writer.write(f"Unknown command: {cmd}", TAG_RED)
+            self.writer.write(f"Unknown command: {cmd}", TAG_ORANGE)
 
     def run_server(self):
         logging.info(f"Server started and listening on {HOST}:{PORT}...")
@@ -491,6 +493,7 @@ TAG_BLACK = 'black'
 TAG_BLUE = 'blue'
 TAG_GREEN = 'green'
 TAG_GREY = 'grey'
+TAG_ORANGE = 'orange'
 TAG_RED = 'red'
 
 class WhisperAttackWriter:
@@ -501,6 +504,7 @@ class WhisperAttackWriter:
         self.text_area.tag_configure(TAG_BLUE, foreground=TAG_BLUE)
         self.text_area.tag_configure(TAG_GREEN, foreground=TAG_GREEN)
         self.text_area.tag_configure(TAG_GREY, foreground=TAG_GREY)
+        self.text_area.tag_configure(TAG_ORANGE, foreground=TAG_ORANGE)
         self.text_area.tag_configure(TAG_RED, foreground=TAG_RED)
         
     def write(self, text, tag):


### PR DESCRIPTION
Add support for displaying a window that can be used to view (colour coded) logged messages. More user friendly than viewing/refreshing the logs to see transcribed text.

The window can be closed without causing WhisperAttack to stop and can be shown again via the system tray.