### PR TITLE
Support configurable Whisper model compute types

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,16 +204,24 @@ ERROR - Failed to transcribe audio: Library cublas64_12.dll is not found or cann
 
 ### ValueError: Requested int8_float16 compute type ###
 
-The below error can be displayed for some GPUs which do not support certain compute types.
+For some GPUs which do not support certain compute types, i.e. do not have tensor cores, the below message will be output to the logs:
+
+```
+WARNING - GPU does not have tensor cores, major=6, minor=1
+```
+
+WhisperAttack can detect this and will fallback on supported values for cuda cores.
+
+If however the below error message is displayed then the `settings.cfg` file can be updated.
 
 ```console
 ValueError: Requested int8_float16 compute type, but the target device or backend do not support efficient int8_float16 computation.
 ```
 
-The `settings.cfg` file can be updated to add the below entry to use another supported compute type:
+The `settings.cfg` file can be updated to add the below entry:
 
 ```console
-whisper_compute_type=int8
+whisper_core_type=standard
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ If the below below is displayed in the logs then ensure that CUDA 12 is availabl
 ERROR - Failed to transcribe audio: Library cublas64_12.dll is not found or cannot be loaded
 ```
 
+### ValueError: Requested int8_float16 compute type ###
+
+The below error can be displayed for some GPUs which do not support certain compute types.
+
+```console
+ValueError: Requested int8_float16 compute type, but the target device or backend do not support efficient int8_float16 computation.
+```
+
+The `settings.cfg` file can be updated to add the below entry to use another supported compute type:
+
+```console
+whisper_compute_type=int8
+```
+
 ---
 
 ## Performance (AI Model)

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -254,14 +254,15 @@ class WhisperServer:
         """
         whisper_model = config.get("whisper_model", "small.en")
         whisper_device = config.get("whisper_device", "CPU")
-        logging.info("Loading Whisper model (%s), device=%s ...", whisper_model, whisper_device)
+        whisper_compute_type = config.get("whisper_compute_type", "int8_float16")
+        logging.info("Loading Whisper model (%s), device=%s, compute_type=%s ...", whisper_model, whisper_device, whisper_compute_type)
         self.writer.write(f"Loading Whisper model ({whisper_model}), device={whisper_device} ...")
         import torch
         from faster_whisper import WhisperModel
         
         if whisper_device.upper() == "GPU":
             if torch.cuda.is_available():
-                self.model = WhisperModel(whisper_model, device="cuda", compute_type="int8_float16")
+                self.model = WhisperModel(whisper_model, device="cuda", compute_type=whisper_compute_type)
                 logging.info('Successfully loaded Whisper model')
                 self.writer.write('Successfully loaded Whisper model', TAG_GREEN)
                 return None

--- a/whisper_server.py
+++ b/whisper_server.py
@@ -254,15 +254,26 @@ class WhisperServer:
         """
         whisper_model = config.get("whisper_model", "small.en")
         whisper_device = config.get("whisper_device", "CPU")
-        whisper_compute_type = config.get("whisper_compute_type", "int8_float16")
-        logging.info("Loading Whisper model (%s), device=%s, compute_type=%s ...", whisper_model, whisper_device, whisper_compute_type)
+        whisper_core_type = config.get("whisper_core_type", "tensor")
+        logging.info("Loading Whisper model (%s), device=%s, core_type=%s ...", whisper_model, whisper_device, whisper_core_type)
         self.writer.write(f"Loading Whisper model ({whisper_model}), device={whisper_device} ...")
         import torch
         from faster_whisper import WhisperModel
         
         if whisper_device.upper() == "GPU":
             if torch.cuda.is_available():
-                self.model = WhisperModel(whisper_model, device="cuda", compute_type=whisper_compute_type)
+                compute_type = "int8_float16"
+                if whisper_core_type.lower() == "standard":
+                    compute_type = "int8"
+                device = torch.device("cuda")
+                capability = torch.cuda.get_device_capability(device)
+                major, minor = capability
+                logging.info("GPU has cuda capability major=%s minor=%s", major, minor)
+                # Tensor Cores are available on devices with compute capability 7.0 or higher
+                if whisper_core_type.lower() == "tensor" and major < 7:
+                    logging.warning("GPU does not have tensor cores, major=%s, minor=%s", major, minor)
+                    compute_type = "int8"
+                self.model = WhisperModel(whisper_model, device="cuda", compute_type=compute_type)
                 logging.info('Successfully loaded Whisper model')
                 self.writer.write('Successfully loaded Whisper model', TAG_GREEN)
                 return None


### PR DESCRIPTION
Some older GPUs that do not have Tensor cores do not support the default int8_float16 compute type we use for Whisper models. This change detects whether or not the GPU has Tensor cores and selects the correct compute type based on this.