### PR TITLE
Use application location based on where the executable is running

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -2,11 +2,6 @@ import os
 import logging
 from theme import THEME_DEFAULT
 
-# Text-file paths for configuration, word mappings, and fuzzy words
-CONFIGURATION_SETTINGS_FILE = "settings.cfg"
-FUZZY_WORDS_TEXT_FILE = "fuzzy_words.txt"
-WORD_MAPPINGS_TEXT_FILE = "word_mappings.txt"
-
 class ConfigurationError(Exception):
     """
     Exception class for errors reading and writing configuration
@@ -21,20 +16,21 @@ class WhisperAttackConfiguration:
     """
     A class to read and write the WhisperAttack configuration
     """
-    def __init__(self):
-        self.config = self.load_configuration()
-        self.word_mappings = self.load_word_mappings()
-        self.fuzzy_words = self.load_fuzzy_words()
+    def __init__(self, location: str):
+        self.config = self.load_configuration(location)
+        self.word_mappings = self.load_word_mappings(location)
+        self.fuzzy_words = self.load_fuzzy_words(location)
 
-    def load_configuration(self) -> dict[str, str]:
+    def load_configuration(self, location: str) -> dict[str, str]:
         """
         Loads configuration settings.
         """
         logging.info("Loading configuration...")
+        settings_file = os.path.join(location, "settings.cfg")
         config = {}
-        if os.path.isfile(CONFIGURATION_SETTINGS_FILE):
+        if os.path.isfile(settings_file):
             try:
-                with open(CONFIGURATION_SETTINGS_FILE, 'r', encoding='utf-8') as f:
+                with open(settings_file, 'r', encoding='utf-8') as f:
                     for line in f:
                         line = line.strip()
                         if not line or line.startswith('#'):
@@ -44,9 +40,10 @@ class WhisperAttackConfiguration:
                             source, target = parts
                             config[source.strip()] = target.strip()
             except Exception as error:
-                logging.error("Failed to load configuration settings from settings.cfg: %s", error)
+                logging.error("Failed to load configuration settings from '%s': %s", settings_file, error)
                 raise ConfigurationError("Failed to load configuration settings") from error
         else:
+            logging.error("File not found: '%s'", settings_file)
             raise ConfigurationError("The configuration settings.cfg file could not be found")
 
         logging.info("Loaded configuration: %s", config)
@@ -69,15 +66,16 @@ class WhisperAttackConfiguration:
         logging.error("VoiceAttack could not be located at: '%s'", voiceattack_location)
         return None
     
-    def load_word_mappings(self) -> dict[str, str]:
+    def load_word_mappings(self, location: str) -> dict[str, str]:
         """
         Loads word mappings from text files.
         """
         logging.info("Loading word mappings...")
+        word_mappings_file = os.path.join(location, "word_mappings.txt")
         word_mappings = {}
-        if os.path.isfile(WORD_MAPPINGS_TEXT_FILE):
+        if os.path.isfile(word_mappings_file):
             try:
-                with open(WORD_MAPPINGS_TEXT_FILE, 'r', encoding='utf-8') as f:
+                with open(word_mappings_file, 'r', encoding='utf-8') as f:
                     for line in f:
                         line = line.strip()
                         if not line or line.startswith('#'):
@@ -88,51 +86,53 @@ class WhisperAttackConfiguration:
                             target = target.strip()
                             list(map(lambda alias: word_mappings.update({ alias: target }), aliases.split(';')))
             except Exception as error:
-                logging.error("Failed to load word mappings from word_mappings.txt: %s", error)
+                logging.error("Failed to load word mappings from '%s': %s", word_mappings_file, error)
                 raise ConfigurationError("Failed to load word mappings") from error
         else:
-            logging.error("word_mappings.txt file not found.")
-            raise ConfigurationError("word_mappings.txt file not found.")
+            logging.error("File not found: '%s'", word_mappings_file)
+            raise ConfigurationError("The word_mappings.txt file could not be found.")
 
         logging.info("Loaded word mappings:")
         for key, value in word_mappings.items():
             logging.info("%s: %s", key, value)
         return word_mappings
     
-    def load_fuzzy_words(self) -> list[str]:
+    def load_fuzzy_words(self, location: str) -> list[str]:
         """
         Loads fuzzy words from text files.
         """
         logging.info("Loading fuzzy words...")
+        fuzzy_words_file = os.path.join(location, "fuzzy_words.txt")
         fuzzy_words = []
-        if os.path.isfile(FUZZY_WORDS_TEXT_FILE):
+        if os.path.isfile(fuzzy_words_file):
             try:
-                with open(FUZZY_WORDS_TEXT_FILE, 'r', encoding='utf-8') as f:
+                with open(fuzzy_words_file, 'r', encoding='utf-8') as f:
                     fuzzy_words = [
                         line.strip() for line in f
                         if line.strip() and not line.strip().startswith('#')
                     ]
             except Exception as error:
-                logging.error("Failed to load fuzzy words from fuzzy_words.txt: %s", error)
+                logging.error("Failed to load fuzzy words from '%s': %s", fuzzy_words_file, error)
                 raise ConfigurationError("Failed to load fuzzy words from fuzzy_words.txt") from error
         else:
-            logging.error("fuzzy_words.txt file not found.")
-            raise ConfigurationError("fuzzy_words.txt file not found.")
+            logging.error("File not found: '%s'", fuzzy_words_file)
+            raise ConfigurationError("The fuzzy_words.txt file could not found.")
 
         logging.info("Loaded fuzzy words: %s", fuzzy_words)
         return fuzzy_words
 
-    def add_word_mapping(self, aliases: str, replacement: str) -> None:
+    def add_word_mapping(self, location: str, aliases: str, replacement: str) -> None:
         """
         Adds a new alias and replacement to the word mappings
         """
         if aliases.strip() == "":
             return None
 
-        list(map(lambda alias: self.word_mappings.update({ alias: replacement }), aliases.split(';')))
-        if os.path.isfile(WORD_MAPPINGS_TEXT_FILE):
+        word_mappings_file = os.path.join(location, "word_mappings.txt")
+        if os.path.isfile(word_mappings_file):
+            list(map(lambda alias: self.word_mappings.update({ alias: replacement }), aliases.split(';')))
             try:
-                with open(WORD_MAPPINGS_TEXT_FILE, 'a', encoding='utf-8') as f:
+                with open(word_mappings_file, 'a', encoding='utf-8') as f:
                     f.write(f"\n{aliases}={replacement}")
                     f.close()
                 logging.info("Added aliases: %s", aliases)

--- a/whisper_attack.py
+++ b/whisper_attack.py
@@ -18,8 +18,19 @@ from writer import WhisperAttackWriter
 from whisper_server import WhisperServer
 from word_mappings import WhisperAttackWordMappings
 
-# This event is used to stop the the server socket and shutdown.
+# This event is used to stop the server socket and shutdown.
 exit_event = threading.Event()
+
+APPLICATION_VERSION = "1.2.1"
+
+# File paths for configuration, word mappings, and fuzzy words
+APPLICATION_PATH = ""
+if getattr(sys, 'frozen', False):
+    # If the application is run as a bundle, the PyInstaller bootloader
+    # extends the sys module by a flag frozen=True
+    APPLICATION_PATH = os.path.dirname(sys.executable)
+else:
+    APPLICATION_PATH = os.path.dirname(__file__)
 
 LOCAL_APPDATA_DIR = os.getenv('LOCALAPPDATA')
 WHISPER_APPDATA_DIR = os.path.join(LOCAL_APPDATA_DIR , "WhisperAttack")
@@ -68,9 +79,11 @@ class WhisperAttack:
     def __init__(self, root: Window):
         start_logging()
 
-        self.root = root
+        logging.info(f"WhisperAttack version: {APPLICATION_VERSION}")
+        logging.info(f"WhisperAttack location: {APPLICATION_PATH}")
 
-        self.config = WhisperAttackConfiguration()
+        self.root = root
+        self.config = WhisperAttackConfiguration(APPLICATION_PATH)
 
         theme = self.get_theme()
         if theme == THEME_DARK:
@@ -134,7 +147,7 @@ class WhisperAttack:
         """
         def update_word_mapping(aliases: str, replacement: str):
             try:
-                self.config.add_word_mapping(aliases, replacement)
+                self.config.add_word_mapping(APPLICATION_PATH, aliases, replacement)
                 self.writer.write("Added new word mapping:", TAG_BLUE)
                 self.writer.write(f"{aliases}: {replacement}", TAG_GREY)
             except ConfigurationError as error:


### PR DESCRIPTION
Fix to resolve an issue where the configuration files couldn't be found by WhisperAttack when attempting to load them. The relative path to these files weren't locating them as expected for one user. The existing logging did not provide enough information as to where it was looking for those files.

The changes in this PR are based on PyInstaller docs, and other internet resources, for locating files relative to where the executable is running from.