### PR TITLE
Store custom configuration and word mappings in user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ Instructions for integrating with VAICOM can be located in the [VAICOM INTEGRATI
 
 ## Configuration
 
+The default configuration files are stored beside the WhisperAttack application. Custom configuration can be kept in
+files of the same name in the `C:\Users\username\AppData\Local\WhisperAttack` directory. These custom files can be created
+if they do not exist and can be used to override (or add to for word mappings) the default configuration.
+
+Keeping custom configuration at that location means it will not be overwritten when installing later versions of WhisperAttack.
+
+See below for the list of configuration files.
+
 ### settings.cfg
 
 The `settings.cfg` file contains configuration for WhisperAttack.
@@ -80,7 +88,7 @@ gulf;gold=Golf
 inter=Inter
 ```
 
-WhisperAttack needs to be restarted after making changes to this file. New word mappings can be added via the configuration screen and do not require a restart.
+WhisperAttack needs to be restarted after making changes to this file. New word mappings can be added via the configuration screen and do not require a restart. When adding new word mappings they will be created in your custom configuration file, `C:\Users\username\AppData\Local\WhisperAttack\word_mappings.txt`
 
 ---
 

--- a/configuration.py
+++ b/configuration.py
@@ -14,20 +14,31 @@ class ConfigurationWarning(Exception):
 
 class WhisperAttackConfiguration:
     """
-    A class to read and write the WhisperAttack configuration
+    A class to read and write the WhisperAttack configuration.
+    Default configuration is loaded from the application directory,
+    custom configuration is loaded from the AppData\Local\WhisperAttack
+    directory and is combined with the default configuration.
     """
-    def __init__(self, location: str):
-        self.config = self.load_configuration(location)
-        self.word_mappings = self.load_word_mappings(location)
-        self.fuzzy_words = self.load_fuzzy_words(location)
+    def __init__(self, app_location: str, app_data_location: str):
+        default_config = self.load_configuration(app_location)
+        custom_config = self.load_configuration(app_data_location, False)
+        self.config = default_config | custom_config
 
-    def load_configuration(self, location: str) -> dict[str, str]:
+        default_word_mappings = self.load_word_mappings(app_location)
+        custom_word_mappings = self.load_word_mappings(app_data_location, False)
+        self.word_mappings = default_word_mappings | custom_word_mappings
+
+        default_fuzzy_words = self.load_fuzzy_words(app_location)
+        custom_fuzzy_words = self.load_fuzzy_words(app_data_location, False)
+        self.fuzzy_words = [*default_fuzzy_words, *custom_fuzzy_words]
+
+    def load_configuration(self, location: str, default = True) -> dict[str, str]:
         """
         Loads configuration settings.
         """
-        logging.info("Loading configuration...")
-        settings_file = os.path.join(location, "settings.cfg")
+        logging.info("Loading %s configuration...", "default" if default else "custom")
         config = {}
+        settings_file = os.path.join(location, "settings.cfg")
         if os.path.isfile(settings_file):
             try:
                 with open(settings_file, 'r', encoding='utf-8') as f:
@@ -42,37 +53,20 @@ class WhisperAttackConfiguration:
             except Exception as error:
                 logging.error("Failed to load configuration settings from '%s': %s", settings_file, error)
                 raise ConfigurationError("Failed to load configuration settings") from error
-        else:
+        elif default:
             logging.error("File not found: '%s'", settings_file)
             raise ConfigurationError("The configuration settings.cfg file could not be found")
 
         logging.info("Loaded configuration: %s", config)
         return config
-    
-    def get_configuration(self) -> dict[str, str]:
-        """
-        Return the full configuration
-        """
-        return self.config
-    
-    def get_voiceattack(self) -> str | None:
-        """
-        Returns the path to the VoiceAttack executable after validating
-        that it is present at the location specified in the configuration.
-        """
-        voiceattack_location = self.config.get("voiceattack_location", "")
-        if os.path.isfile(voiceattack_location):
-            return voiceattack_location
-        logging.error("VoiceAttack could not be located at: '%s'", voiceattack_location)
-        return None
-    
-    def load_word_mappings(self, location: str) -> dict[str, str]:
+
+    def load_word_mappings(self, location: str, default = True) -> dict[str, str]:
         """
         Loads word mappings from text files.
         """
-        logging.info("Loading word mappings...")
-        word_mappings_file = os.path.join(location, "word_mappings.txt")
+        logging.info("Loading %s word mappings...", "default" if default else "custom")
         word_mappings = {}
+        word_mappings_file = os.path.join(location, "word_mappings.txt")
         if os.path.isfile(word_mappings_file):
             try:
                 with open(word_mappings_file, 'r', encoding='utf-8') as f:
@@ -88,7 +82,7 @@ class WhisperAttackConfiguration:
             except Exception as error:
                 logging.error("Failed to load word mappings from '%s': %s", word_mappings_file, error)
                 raise ConfigurationError("Failed to load word mappings") from error
-        else:
+        elif default:
             logging.error("File not found: '%s'", word_mappings_file)
             raise ConfigurationError("The word_mappings.txt file could not be found.")
 
@@ -96,14 +90,14 @@ class WhisperAttackConfiguration:
         for key, value in word_mappings.items():
             logging.info("%s: %s", key, value)
         return word_mappings
-    
-    def load_fuzzy_words(self, location: str) -> list[str]:
+
+    def load_fuzzy_words(self, location: str, default = True) -> list[str]:
         """
         Loads fuzzy words from text files.
         """
-        logging.info("Loading fuzzy words...")
-        fuzzy_words_file = os.path.join(location, "fuzzy_words.txt")
+        logging.info("Loading %s fuzzy words...", "default" if default else "custom")
         fuzzy_words = []
+        fuzzy_words_file = os.path.join(location, "fuzzy_words.txt")
         if os.path.isfile(fuzzy_words_file):
             try:
                 with open(fuzzy_words_file, 'r', encoding='utf-8') as f:
@@ -114,7 +108,7 @@ class WhisperAttackConfiguration:
             except Exception as error:
                 logging.error("Failed to load fuzzy words from '%s': %s", fuzzy_words_file, error)
                 raise ConfigurationError("Failed to load fuzzy words from fuzzy_words.txt") from error
-        else:
+        elif default:
             logging.error("File not found: '%s'", fuzzy_words_file)
             raise ConfigurationError("The fuzzy_words.txt file could not found.")
 
@@ -128,47 +122,49 @@ class WhisperAttackConfiguration:
         if aliases.strip() == "":
             return None
 
+        list(map(lambda alias: self.word_mappings.update({ alias: replacement }), aliases.split(';')))
         word_mappings_file = os.path.join(location, "word_mappings.txt")
-        if os.path.isfile(word_mappings_file):
-            list(map(lambda alias: self.word_mappings.update({ alias: replacement }), aliases.split(';')))
-            try:
-                with open(word_mappings_file, 'a', encoding='utf-8') as f:
-                    f.write(f"\n{aliases}={replacement}")
-                    f.close()
-                logging.info("Added aliases: %s", aliases)
-                logging.info("Added replacement: %s", replacement)
-            except Exception as error:
-                logging.error("Failed to add new word mapping to word_mappings.txt file: %s", error)
-                raise ConfigurationError("Failed to add new word mapping to word_mappings.txt file") from error
-        else:
-            logging.error("word_mappings.txt file not found; no custom word mappings added.")
-            raise ConfigurationError("word_mappings.txt file not found; no custom word mappings added.")
+        try:
+            with open(word_mappings_file, 'a', encoding='utf-8') as f:
+                f.write(f"\n{aliases}={replacement}")
+                f.close()
+            logging.info("Added aliases: %s", aliases)
+            logging.info("Added replacement: %s", replacement)
+        except Exception as error:
+            logging.error("Failed to add new word mapping to word_mappings.txt file: %s", error)
+            raise ConfigurationError("Failed to add new word mapping to word_mappings.txt file") from error
+
+    def get_configuration(self) -> dict[str, str]:
+        """
+        Return the full configuration
+        """
+        return self.config
 
     def get_word_mappings(self) -> dict[str, str]:
         """
         Returns the keyword mappings
         """
         return self.word_mappings
-    
+
     def get_fuzzy_words(self) -> list[str]:
         """
         Returns the fuzzy words list
         """
         return self.fuzzy_words
-    
+
     def get_whisper_model(self) -> str:
         """
         Returns the Whisper model to use for speech-to-text
         """
         return self.config.get("whisper_model", "small.en")
-    
+
     def get_whisper_device(self) -> str:
         """
         Returns the device to use for processing speech-to-text
         GPU or CPU, defaults to GPU
         """
         return self.config.get("whisper_device", "GPU")
-    
+
     def get_whisper_core_type(self) -> str:
         """
         Returns type of GPU cores used for the compute type for processing
@@ -176,7 +172,7 @@ class WhisperAttackConfiguration:
         tensor or standard, defaults to tensor
         """
         return self.config.get("whisper_core_type", "tensor")
-    
+
     def get_theme(self) -> str:
         """
         Returns the name of the theme to be used when displaying
@@ -184,3 +180,14 @@ class WhisperAttackConfiguration:
         the name returned will be the current Windows theme.
         """
         return self.config.get("theme", THEME_DEFAULT)
+
+    def get_voiceattack(self) -> str | None:
+        """
+        Returns the path to the VoiceAttack executable after validating
+        that it is present at the location specified in the configuration.
+        """
+        voiceattack_location = self.config.get("voiceattack_location", "")
+        if os.path.isfile(voiceattack_location):
+            return voiceattack_location
+        logging.error("VoiceAttack could not be located at: '%s'", voiceattack_location)
+        return None

--- a/whisper_attack.py
+++ b/whisper_attack.py
@@ -83,7 +83,7 @@ class WhisperAttack:
         logging.info(f"WhisperAttack location: {APPLICATION_PATH}")
 
         self.root = root
-        self.config = WhisperAttackConfiguration(APPLICATION_PATH)
+        self.config = WhisperAttackConfiguration(APPLICATION_PATH, WHISPER_APPDATA_DIR)
 
         theme = self.get_theme()
         if theme == THEME_DARK:
@@ -147,7 +147,7 @@ class WhisperAttack:
         """
         def update_word_mapping(aliases: str, replacement: str):
             try:
-                self.config.add_word_mapping(APPLICATION_PATH, aliases, replacement)
+                self.config.add_word_mapping(WHISPER_APPDATA_DIR, aliases, replacement)
                 self.writer.write("Added new word mapping:", TAG_BLUE)
                 self.writer.write(f"{aliases}: {replacement}", TAG_GREY)
             except ConfigurationError as error:


### PR DESCRIPTION
Support the ability to store custom user configuration and word mappings in the AppData\Local\WhisperAttack directory so that users can override the defaults, and add word mappings, without this being lost when installing later versions of WhisperAttack.