### PR TITLE
Add support for configuring a specific compute type

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -164,6 +164,12 @@ class WhisperAttackConfiguration:
         GPU or CPU, defaults to GPU
         """
         return self.config.get("whisper_device", "GPU")
+    
+    def get_whisper_compute_type(self) -> str:
+        """
+        Returns the compute type to be used when loading the Whisper model
+        """
+        return self.config.get("whisper_compute_type", "default")
 
     def get_whisper_core_type(self) -> str:
         """

--- a/whisper_attack.py
+++ b/whisper_attack.py
@@ -48,6 +48,9 @@ def start_logging() -> None:
         level=logging.INFO,
         format='%(asctime)s - %(levelname)s - %(message)s'
     )
+    logging.getLogger().setLevel(logging.INFO)
+    logging.getLogger("faster_whisper").setLevel(logging.DEBUG)
+
 
 ###############################################################################
 # ADMIN PRIVILEGES CHECK AND RE-LAUNCH


### PR DESCRIPTION
Previously WhisperAttack was hardcoded to use "int8_float16" for the compute type when loading the model. Based on CTranslate2 logging this is the same compute type as when running with "auto" on my system. Based on the docs (https://opennmt.net/CTranslate2/quantization.html) "auto" is supposed to "use the fastest computation type that is supported on this system and device". This may not necessarily be true of all machines / models, although I have no hard evidence of this given lack of performance testing across multiple users and systems. When compute type is set to "default" this from the docs states "keep the same quantization that was used during model conversion". In my case with the Whisper models this is "float16", and in initial testing I found this option to be more performant.

The intent of this PR is to provide greater flexibility with choosing the compute type to be used. For example, for me I found "default" (which is "float16" for these models) to be more performant based on limited testing. I've chosen to use "default" as the fallback in the configuration, but users can use "auto" if they desire to see if this works better for them. This, based on internal logging, matches the previous hardcoded "int8_float16" value.

This can be controlled with the settings.cfg file using the "whisper_compute_type" option. For example, if wanting to use the previous value.

whisper_compute_type=auto

I'm currently testing this as a beta with another user to see what their experience is like re: performance with different options. Will continue to keep testing to determine whether or not the fallback value should be changed to "auto" (or "int8_float16").

Refer to the docs for more information on these: https://opennmt.net/CTranslate2/quantization.html