### PR TITLE
Support configuring the VoiceAttack plugin for the ip address and port to listen on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ dist
 build
 
 whisper_server.exe
+
+VoiceAttackPlugin/WhisperAttack/.vs
+VoiceAttackPlugin/WhisperAttack/bin
+VoiceAttackPlugin/WhisperAttack/obj
+VoiceAttackPlugin/WhisperAttack/WhisperAttack.csproj.user

--- a/VoiceAttackPlugin/WhisperAttack/Properties/AssemblyInfo.cs
+++ b/VoiceAttackPlugin/WhisperAttack/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WhisperAttack")]
+[assembly: AssemblyDescription("A VoiceAttack plugin for WhisperAttack")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WhisperAttack")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e4003fec-7629-4a6a-a7fe-e012406bb98b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+[assembly: AssemblyVersion("1.2.2.0")]
+[assembly: AssemblyFileVersion("1.2.2.0")]

--- a/VoiceAttackPlugin/WhisperAttack/WhisperAttack.cs
+++ b/VoiceAttackPlugin/WhisperAttack/WhisperAttack.cs
@@ -7,42 +7,66 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace WhisperAttackServerCommand
+namespace WhisperAttack
 {
-    public class VA_Plugin
+    public class WhisperAttackServerCommand
     {
         private static bool _isRunning = true;
         private static TcpListener _listener = null;
         private static IPAddress _listenerIpAddress = IPAddress.Parse("127.0.0.1");
         private static int _listenerPort = 65433;
 
+        /// <summary>
+        /// The plugin’s display name, required by the VoiceAttack plugin API.
+        /// </summary>
+        /// <returns>The display name.</returns>
         public static string VA_DisplayName()
         {
             return "WhisperAttack";
         }
 
+        /// <summary>
+        /// The plugin’s description, required by the VoiceAttack plugin API.
+        /// </summary>
+        /// <returns>The description.</returns>
         public static string VA_DisplayInfo()
         {
             return "WhisperAttack Server Command plugin (v1.2.2)";
         }
 
+        /// <summary>
+        /// The plugin’s GUID, required by the VoiceAttack plugin API.
+        /// </summary>
+        /// <returns>The GUID.</returns>
         public static Guid VA_Id()
         {
             return new Guid("{1AD02372-145E-4143-BBBE-AC7575595C24}");
         }
 
+        /// <summary>
+        /// VoiceAttack calls this when a command is run to stop all running commands.
+        /// This is currently unused.
+        /// </summary>
         public static void VA_StopCommand()
         {
+            // no-op
         }
 
+        /// <summary>
+        /// Invoked when the plugin is loaded. This runs a connection test to see if the WhisperAttack
+        /// server is currently running, and starts up the listener for receiving commands.
+        /// </summary>
+        /// <param name="vaProxy">The VoiceAttack proxy for calling VoiceAttack functions</param>
         public static void VA_Init1(dynamic vaProxy)
         {
-            // Configuration for connecting to the WhisperAttack server.
-            string server = "127.0.0.1";
-            int port = 65432;
-
+            // Run a connection test to see if WhisperAttack is currently running and
+            // listening for server commands.
             try
             {
+                // Configuration for connecting to the WhisperAttack server.
+                string server = "127.0.0.1";
+                int port = 65432;
+
                 using (TcpClient client = new TcpClient(server, port))
                 using (NetworkStream stream = client.GetStream())
                 {
@@ -54,10 +78,14 @@ namespace WhisperAttackServerCommand
                 vaProxy.WriteToLog($"Failed to connect to WhisperAttack server: {ex.Message}", "red");
             }
 
-            loadConfiguration(vaProxy);
+            LoadConfiguration(vaProxy);
             StartCommandListener(vaProxy);
         }
 
+        /// <summary>
+        /// Sends the start/stop recording commands to the WhisperAttack server.
+        /// </summary>
+        /// <param name="vaProxy">The VoiceAttack proxy for calling VoiceAttack functions</param>
         public static void VA_Invoke1(dynamic vaProxy)
         {
             string server = "127.0.0.1";
@@ -98,6 +126,11 @@ namespace WhisperAttackServerCommand
             }
         }
 
+        /// <summary>
+        /// Send the shudown command to the WhisperAttack server when VoiceAttack exits.
+        /// This will close WhisperAttack so that it is no longer running.
+        /// </summary>
+        /// <param name="vaProxy">The VoiceAttack proxy for calling VoiceAttack functions</param>
         public static void VA_Exit1(dynamic vaProxy)
         {
             _isRunning = false;
@@ -115,11 +148,19 @@ namespace WhisperAttackServerCommand
             }
         }
 
-        private static void loadConfiguration(dynamic vaProxy)
+        /// <summary>
+        /// Loads the configuration from the settings.cfg file in the same location as the plugin.
+        /// Configuration is in the format key=value
+        /// Configuration specifies the ip address and port for listening on to receive text commands.
+        /// </summary>
+        /// <param name="vaProxy">The VoiceAttack proxy for calling VoiceAttack functions</param>
+        private static void LoadConfiguration(dynamic vaProxy)
         {
-            string settingsFile = "Apps\\WhisperAttackServerCommand\\settings.cfg";
-            string currentDir = Directory.GetCurrentDirectory();
-            string filePath = Path.Combine(currentDir, settingsFile);
+            // Get the VoiceAttack directory that contains plugins
+            string voiceAttackAppsDir = vaProxy.SessionState["VA_APPS"];
+            // Create the path to the WhisperAttack plugin directory and configuration file under the folder
+            // that VoiceAttack keeps plugins in.
+            string filePath = Path.Combine(voiceAttackAppsDir, "WhisperAttackServerCommand\\settings.cfg");
 
             // Read the configuration file, if it exists, in the format key=value
             if (!File.Exists(filePath))
@@ -132,7 +173,7 @@ namespace WhisperAttackServerCommand
             {
                 foreach (var line in File.ReadAllLines(filePath))
                 {
-                    // Trim whitespace and skip empty or comment lines
+                    // Trim whitespace and skip empty or commented out lines
                     var trimmed = line.Trim();
                     if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#"))
                         continue;
@@ -149,6 +190,7 @@ namespace WhisperAttackServerCommand
                         {
                             if (key.Equals("listener_address"))
                             {
+                                // Check if the value provided is a valid IP address
                                 if (!IPAddress.TryParse(value, out IPAddress ipAddress))
                                 {
                                     vaProxy.WriteToLog($"Invalid listener ip address {value}, using default 127.0.0.1", "red");
@@ -162,7 +204,7 @@ namespace WhisperAttackServerCommand
                             {
                                 try
                                 {
-
+                                    // Check if the listener port is a valid number
                                     _listenerPort = int.Parse(value);
                                 }
                                 catch
@@ -188,6 +230,12 @@ namespace WhisperAttackServerCommand
             }
         }
 
+        /// <summary>
+        /// Start the TCP listener for receiving text commands.
+        /// This is run as a Task so that it does not block the main plugin thread while listening.
+        /// </summary>
+        /// <param name="vaProxy">The VoiceAttack proxy for calling VoiceAttack functions</param>
+        /// <returns></returns>
         private static async Task StartCommandListener(dynamic vaProxy)
         {
             vaProxy.WriteToLog($"Starting WhisperAttack listener on {_listenerIpAddress}:{_listenerPort}", "blue");
@@ -210,6 +258,13 @@ namespace WhisperAttackServerCommand
             }
         }
 
+        /// <summary>
+        /// Handler for commands received by listener and then execute the associated VoiceAttack command.
+        /// Run as a Task so that it does not block the main plugin thread.
+        /// </summary>
+        /// <param name="vaProxy">The VoiceAttack proxy for calling VoiceAttack functions</param>
+        /// <param name="client">The TCP client to read from the received command from</param>
+        /// <returns></returns>
         private static async Task HandleWhisperAttackCommand(dynamic vaProxy, TcpClient client)
         {
             await Task.Yield();
@@ -224,6 +279,9 @@ namespace WhisperAttackServerCommand
 
                     vaProxy.WriteToLog($"Received WhisperAttack command: '{receivedMessage}'", "grey");
 
+                    // If the command exists within the VoiceAttack profile then run it.
+                    // We check for the command first so that we can log this nicely vs. the generic
+                    // external command failure.
                     if (vaProxy.Command.Exists(receivedMessage))
                     {
                         vaProxy.Command.Execute(receivedMessage, true, true);

--- a/VoiceAttackPlugin/WhisperAttack/WhisperAttack.csproj
+++ b/VoiceAttackPlugin/WhisperAttack/WhisperAttack.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="VoiceAttack">
       <HintPath>C:\Program Files (x86)\VoiceAttack\VoiceAttack.exe</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VoiceAttackPlugin/WhisperAttack/WhisperAttack.csproj
+++ b/VoiceAttackPlugin/WhisperAttack/WhisperAttack.csproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E4003FEC-7629-4A6A-A7FE-E012406BB98B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WhisperAttack</RootNamespace>
+    <AssemblyName>WhisperAttack</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="VoiceAttack">
+      <HintPath>C:\Program Files (x86)\VoiceAttack\VoiceAttack.exe</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="WhisperAttack.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/VoiceAttackPlugin/WhisperAttack/WhisperAttack.sln
+++ b/VoiceAttackPlugin/WhisperAttack/WhisperAttack.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36623.8 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhisperAttack", "WhisperAttack.csproj", "{E4003FEC-7629-4A6A-A7FE-E012406BB98B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E4003FEC-7629-4A6A-A7FE-E012406BB98B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4003FEC-7629-4A6A-A7FE-E012406BB98B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4003FEC-7629-4A6A-A7FE-E012406BB98B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4003FEC-7629-4A6A-A7FE-E012406BB98B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {57FDF13E-DA85-45AC-B98A-F06B1E5F3C78}
+	EndGlobalSection
+EndGlobal

--- a/VoiceAttackPlugin/WhisperAttack/settings.cfg
+++ b/VoiceAttackPlugin/WhisperAttack/settings.cfg
@@ -1,0 +1,5 @@
+# IP address and port for the plugin to listen on for receiving
+# text commands to execute in VoiceAttack.
+# Defaults to 127.0.0.1:65433
+#listener_address=127.0.0.1
+#listener_port=65433


### PR DESCRIPTION
The VA plugin is currently hardcoded to listen on 127.0.0.1:35433 for incoming text to execute as commands. This needs to be configurable in case of port conflicts, or needing to receive commands from a remote server.

Configuration is read from a settings.cfg file for the following config items:
- listener_address
- listener_port